### PR TITLE
gmscompat: don't use "/proc/self/fd" paths for loading Dynamite modules

### DIFF
--- a/runtime/oat_file_manager.cc
+++ b/runtime/oat_file_manager.cc
@@ -390,8 +390,8 @@ std::vector<std::unique_ptr<const DexFile>> OatFileManager::OpenDexFilesFromOat(
     static constexpr bool kVerifyChecksum = true;
     const ArtDexFileLoader dex_file_loader;
     int fd;
-    if (!strncmp("/proc/self/fd/", dex_location, strlen("/proc/self/fd/")) &&
-          sscanf(dex_location, "/proc/self/fd/%d", &fd) == 1) {
+    if (!strncmp("/gmscompat_fd_", dex_location, strlen("/gmscompat_fd_")) &&
+          sscanf(dex_location, "/gmscompat_fd_%d", &fd) == 1) {
       fd = dup(fd);
     } else {
       fd = open(dex_location, O_RDONLY | O_CLOEXEC);


### PR DESCRIPTION
dup()-ing fd that is referred to by "/proc/self/fd" path isn't the same
as open()-ing that path. fd that is returned by dup() refers to the same
underlying file description and thus shares position and file status
flags with the original fd.

The ability to pass "/proc/self/fd" path instead of a file path
is an undocumented API on Android, but there are apps that depend on it.