### PR TITLE
customize AOT compiler filter adjustment logic

### DIFF
--- a/libartservice/service/java/com/android/server/art/Dexopter.java
+++ b/libartservice/service/java/com/android/server/art/Dexopter.java
@@ -304,13 +304,8 @@ public abstract class Dexopter<DexInfoType extends DetailedDexInfo> {
     @NonNull
     private String adjustCompilerFilter(
             @NonNull String targetCompilerFilter, @NonNull DexInfoType dexInfo) {
-        if (mInjector.isSystemUiPackage(mPkgState.getPackageName())) {
-            String systemUiCompilerFilter = getSystemUiCompilerFilter();
-            if (!systemUiCompilerFilter.isEmpty()) {
-                targetCompilerFilter = systemUiCompilerFilter;
-            }
-        } else if (mInjector.isLauncherPackage(mPkgState.getPackageName())) {
-            targetCompilerFilter = "speed-profile";
+        if (mPkgState.isSystem()) {
+            targetCompilerFilter = "speed";
         }
 
         // Code below should only downgrade the compiler filter. Don't upgrade the compiler filter

--- a/libartservice/service/java/com/android/server/art/Dexopter.java
+++ b/libartservice/service/java/com/android/server/art/Dexopter.java
@@ -304,10 +304,6 @@ public abstract class Dexopter<DexInfoType extends DetailedDexInfo> {
     @NonNull
     private String adjustCompilerFilter(
             @NonNull String targetCompilerFilter, @NonNull DexInfoType dexInfo) {
-        if (mPkgState.isSystem()) {
-            return "speed";
-        }
-
         if (mInjector.isSystemUiPackage(mPkgState.getPackageName())) {
             String systemUiCompilerFilter = getSystemUiCompilerFilter();
             if (!systemUiCompilerFilter.isEmpty()) {


### PR DESCRIPTION
- use "speed" compiler filter by default for system packages, including SystemUI and Launcher
- allow to use "verify" instead of "speed" for system packages that have useEmbeddedDex=true
AndroidManifest attribute (e.g. Auditor app). AOT compilation results are not executed for such
packages, regardless of the used compiler filter
- remove "speed-profile" override for current launcher. This override made third-party launchers
use the interpreter-only mode if they didn't include a profile, since the ART JIT compiler is
disabled on GrapheneOS

Test for third-party launcher handling change:
LPKG=`<current launcher package name>`
- `adb shell pm delete-dexopt $LPKG` to delete its current optimized code, if any
- `adb shell pm compile -r bg-dexopt $LPKG` to re-optimize it
- `adb shell pm art dump $LPKG`. Observe that `status=speed`, not `speed-profile`

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/3344