### PR TITLE
Revert "Remove strip.keep_symbols from libart defaults"

### DIFF
--- a/runtime/Android.bp
+++ b/runtime/Android.bp
@@ -43,6 +43,37 @@ cc_defaults {
                 "-Wno-unused-command-line-argument",
             ],
         },
+        android_arm: {
+            // Arm 32 bit does not produce complete exidx unwind information
+            // so keep the .debug_frame which is relatively small and does
+            // include needed unwind information.
+            // See b/132992102 and b/145790995 for details.
+            strip: {
+                keep_symbols_and_debug_frame: true,
+            },
+        },
+        // For all other architectures, leave the symbols in the shared library
+        // so that stack unwinders can produce meaningful name resolution.
+        android_arm64: {
+            strip: {
+                keep_symbols: true,
+            },
+        },
+        android_riscv64: {
+            strip: {
+                keep_symbols: true,
+            },
+        },
+        android_x86: {
+            strip: {
+                keep_symbols: true,
+            },
+        },
+        android_x86_64: {
+            strip: {
+                keep_symbols: true,
+            },
+        },
     },
 }
 


### PR DESCRIPTION
Closes 
https://github.com/GrapheneOS/os-issue-tracker/issues/3311
https://github.com/GrapheneOS/os-issue-tracker/issues/3317