### PR TITLE
[temporary] disable asynchronous pre-reboot dexopt

### DIFF
--- a/libartservice/service/java/com/android/server/art/PreRebootDexoptJob.java
+++ b/libartservice/service/java/com/android/server/art/PreRebootDexoptJob.java
@@ -585,11 +585,7 @@ public class PreRebootDexoptJob implements ArtServiceJobInterface {
     }
 
     public boolean isAsyncForOta() {
-        if (android.os.Flags.updateEngineApi()) {
-            return true;
-        }
-        // Legacy flag in Android V.
-        return SystemProperties.getBoolean("dalvik.vm.pr_dexopt_async_for_ota", false /* def */);
+        return false;
     }
 
     @GuardedBy("this")


### PR DESCRIPTION
Properly adapting to the async pre-reboot dexopt requires extensive changes.